### PR TITLE
change parseGPU format to more smart

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -59,7 +59,7 @@ std::string parseGPU(std::vector<int> &result_gpus, std::string_view gpuRange) {
     }
 
     const auto dash = range.find('-');
-    if (dash == std::basic_string_view<char>::npos) {
+    if (dash == std::basic_string<char>::npos) {
       return "dash is missed";
     }
     if (dash == 0) {


### PR DESCRIPTION
* теперь parseGPU принимает строки вида `[1,2-4,5,7-10]` и тд.
* исправлен баг, при котором можно было несколько раз указать одну и ту же GPU